### PR TITLE
Update to gnome 3.28 runtime

### DIFF
--- a/gegl-0-20-0-fix-with-new-glib-mkenums.patch
+++ b/gegl-0-20-0-fix-with-new-glib-mkenums.patch
@@ -1,0 +1,39 @@
+diff -up gegl-2/gegl/gegl-enums.h.mkenums gegl-2/gegl/gegl-enums.h
+--- gegl-2/gegl/gegl-enums.h.mkenums	2018-04-06 08:52:15.075045457 +0200
++++ gegl-2/gegl/gegl-enums.h	2018-04-06 08:56:49.064313865 +0200
+@@ -32,10 +32,10 @@
+ G_BEGIN_DECLS
+ 
+ typedef enum {
+-  GEGL_SAMPLER_NEAREST = 0,   /*< desc="nearest"      >*/
+-  GEGL_SAMPLER_LINEAR,        /*< desc="linear"       >*/
+-  GEGL_SAMPLER_CUBIC,         /*< desc="cubic"        >*/
+-  GEGL_SAMPLER_LOHALO         /*< desc="lohalo"       >*/
++  GEGL_SAMPLER_NEAREST = 0,   /*< desc="nearest" , nick=nearest >*/
++  GEGL_SAMPLER_LINEAR,        /*< desc="linear" , nick=linear >*/
++  GEGL_SAMPLER_CUBIC,         /*< desc="cubic"  , nick=cubic >*/
++  GEGL_SAMPLER_LOHALO         /*< desc="lohalo" , nick=lohalo >*/
+ } GeglSamplerType;
+ GType gegl_sampler_type_get_type   (void) G_GNUC_CONST;
+ #define GEGL_TYPE_SAMPLER_TYPE (gegl_sampler_type_get_type())
+@@ -59,13 +59,13 @@ GType gegl_ripple_wave_type_get_type   (
+ 
+ typedef enum
+ {
+-  GEGL_WARP_BEHAVIOR_MOVE,      /*< desc="Move pixels"              >*/
+-  GEGL_WARP_BEHAVIOR_GROW,      /*< desc="Grow area"                >*/
+-  GEGL_WARP_BEHAVIOR_SHRINK,    /*< desc="Shrink area"              >*/
+-  GEGL_WARP_BEHAVIOR_SWIRL_CW,  /*< desc="Swirl clockwise"          >*/
+-  GEGL_WARP_BEHAVIOR_SWIRL_CCW, /*< desc="Swirl counter-clockwise"  >*/
+-  GEGL_WARP_BEHAVIOR_ERASE,     /*< desc="Erase warping"            >*/
+-  GEGL_WARP_BEHAVIOR_SMOOTH     /*< desc="Smooth warping"           >*/
++  GEGL_WARP_BEHAVIOR_MOVE,      /*< desc="Move pixels"     ,  nick=move       >*/
++  GEGL_WARP_BEHAVIOR_GROW,      /*< desc="Grow area"       ,  nick=grow       >*/
++  GEGL_WARP_BEHAVIOR_SHRINK,    /*< desc="Shrink area"     ,  nick=shrink       >*/
++  GEGL_WARP_BEHAVIOR_SWIRL_CW,  /*< desc="Swirl clockwise" ,  nick=swirl-cw       >*/
++  GEGL_WARP_BEHAVIOR_SWIRL_CCW, /*< desc="Swirl counter-clockwise" , nick=swirl-ccw >*/
++  GEGL_WARP_BEHAVIOR_ERASE,     /*< desc="Erase warping"      ,   nick=erase   >*/
++  GEGL_WARP_BEHAVIOR_SMOOTH     /*< desc="Smooth warping"     ,   nick=smooth   >*/
+ } GeglWarpBehavior;
+ GType gegl_warp_behavior_get_type (void) G_GNUC_CONST;
+ #define GEGL_TYPE_WARP_BEHAVIOR (gegl_warp_behavior_get_type ())

--- a/org.gimp.BaseApp.json
+++ b/org.gimp.BaseApp.json
@@ -3,7 +3,7 @@
     "branch": "stable",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
-    "runtime-version": "3.24",
+    "runtime-version": "3.28",
     "command": "/usr/bin/bash",
     "build-options" : {
         "cflags": "-O2 -g",

--- a/org.gimp.GIMP.WithBase.json
+++ b/org.gimp.GIMP.WithBase.json
@@ -4,7 +4,7 @@
     "base": "org.gimp.BaseApp",
     "base-version": "stable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "gimp-2.8",
     "rename-desktop-file": "gimp.desktop",

--- a/org.gimp.GIMP.app-modules.json
+++ b/org.gimp.GIMP.app-modules.json
@@ -23,6 +23,11 @@
                     "url": "git://git.gnome.org/gegl",
                     "branch": "GEGL_0_2_0",
                     "commit": "57e23d310291a632ea8e16b7b8e5b97f7f289680"
+                },
+                {
+                    "type": "patch",
+                    /* There is an issue with the new glib-mkenums, see bugzilla.gnome.org 795008 */
+                    "path": "gegl-0-20-0-fix-with-new-glib-mkenums.patch"
                 }
             ]
         },

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -2,7 +2,7 @@
     "id": "org.gimp.GIMP",
     "branch": "stable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "gimp-2.8",
     "rename-desktop-file": "gimp.desktop",


### PR DESCRIPTION
This also needs a minor patch to gegl because of a regression
in glib-mkenums (https://bugzilla.gnome.org/show_bug.cgi?id=795008)