### PR TITLE
Use app-id not id in the manifest

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.gimp.GIMP",
+    "app-id": "org.gimp.GIMP",
     "branch": "stable",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.28",


### PR DESCRIPTION
According to the documentation we should use "app-id" and not "id" in the manifest:
http://docs.flatpak.org/en/latest/manifests.html