### PR TITLE
manifest: Remove access to the host files

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -10,7 +10,7 @@
     "rename-icon": "gimp",
     "finish-args": ["--share=ipc", "--share=network",
                     "--socket=x11", "--socket=wayland",
-                    "--filesystem=host", "--filesystem=xdg-config/GIMP",
+                    "--filesystem=xdg-config/GIMP",
                     "--filesystem=xdg-config/gtk-3.0", "--filesystem=/tmp",
                     "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*" ],
     "tags": ["stable"],


### PR DESCRIPTION
I couldn't find a justification for accessing all the files on the host,
so I attempt to remove that access to increase the security of the sandbox.