### PR TITLE
Remove unused Wayland permission

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -9,7 +9,7 @@
     "rename-desktop-file": "gimp.desktop",
     "rename-icon": "gimp",
     "finish-args": ["--share=ipc", "--share=network",
-                    "--socket=x11", "--socket=wayland",
+                    "--socket=x11",
                     "--filesystem=host", "--filesystem=xdg-config/GIMP",
                     "--filesystem=xdg-config/gtk-3.0", "--filesystem=/tmp",
                     "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*" ],


### PR DESCRIPTION
GIMP doesn't support Wayland... so why have it.