### PR TITLE
Sync a bit with shared-modules/gtk2/gtk2.json.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -133,8 +133,8 @@
                         "/lib/gtk-2.0/2.10.0/immodules.cache"
                     ],
                     "post-install": [
-                        "install -m644 --target-directory=/app/lib/gtk-2.0/2.10.0/immodules client/gtk2/.libs/im-ibus.so",
-                        "gtk-query-immodules-2.0 > /app/lib/gtk-2.0/2.10.0/immodules.cache"
+                        "install -m644 --target-directory=${FLATPAK_DEST}/lib/gtk-2.0/2.10.0/immodules client/gtk2/.libs/im-ibus.so",
+                        "gtk-query-immodules-2.0 > ${FLATPAK_DEST}/lib/gtk-2.0/2.10.0/immodules.cache"
                     ],
                     "sources": [
                         {


### PR DESCRIPTION
When building ibus-gtk2, in somme shell commands, it uses
${FLATPAK_DEST}. I don't think it is big of a problem to use old style
absolute directory (probably stays the same), but it's a good practice
and it's nice we have this variable in our manifest to even just know it
exists for other parts of the build.
Also it's better to keep the gtk2 shared module which is (mostly) copied
into our own manifest as close as possible.