### PR TITLE
Prepare GIMP 2.10.18.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -515,7 +515,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "branch": "master"
+                    "commit": "624335f2b2fb7064ac2b7cba9d1b053c88186af6"
                 }
             ]
         },
@@ -530,7 +530,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "branch": "gimp-2-10"
+                    "branch": "GIMP_2_10_18",
+                    "commit": "de7f04567d16b7192c00378059e91ed026b0c151"
                 },
                 {
                     "type": "patch",

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -515,8 +515,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "branch": "GEGL_0_4_20",
-                    "commit": "ef8b69c06d1c4c0502a09f18bd70c5c6effe587b"
+                    "branch": "master"
                 }
             ]
         },
@@ -524,14 +523,14 @@
             "name": "gimp",
             "config-opts": [ "--disable-docs", "--disable-gtk-doc", "--disable-gtk-doc-html",
                              "--with-icc-directory=/run/host/usr/share/color/icc/",
-                             "--with-build-id=org.gimp.GIMP.flatpak.stable"],
+                             "--with-build-id=org.gimp.GIMP.flatpak.stable",
+                              "--disable-check-update" ],
             "cleanup": [ "/bin/gimptool-2.0", "/bin/gimp-console-2.10", "/bin/gimp-console" ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "branch": "GIMP_2_10_16",
-                    "commit": "fe60c0ffac85c9342bf9daf162f9d3a0b6096ff9"
+                    "branch": "gimp-2-10"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
Yeah already! Some nasty bug was found, so we sneak in a GIMP 2.10.18
even before 2.10.16 is officially announced.
Also take the opportunity to disable update check because flatpak has
auto-update.

Building with HEAD of GEGL as a new release will happen in-between and
we already require the dev version.