### PR TITLE
Added DRI access

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -10,6 +10,7 @@
     "rename-icon": "gimp",
     "finish-args": ["--share=ipc", "--share=network",
                     "--socket=x11",
+                    "--device=dri",
                     "--filesystem=host", "--filesystem=xdg-config/GIMP",
                     "--filesystem=xdg-config/gtk-3.0", "--filesystem=/tmp",
                     "--filesystem=xdg-run/gvfs",


### PR DESCRIPTION
GMic complain about GL. So we need enable DRI permissions. I also wonder if GEGL using the GPU wouldn't complain either.