### PR TITLE
Add libtiff in our build.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -516,6 +516,18 @@
             ]
         },
         {
+            "name": "libtiff",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.com/libtiff/libtiff",
+                    "tag": "v4.1.0",
+                    "commit": "e0d707dc1524d8c0e20f03396f234e0f1b07b3f4"
+                }
+            ]
+        },
+        {
             "name": "babl",
             "buildsystem": "meson",
             "config-opts": [ "-Dwith-docs=false" ],


### PR DESCRIPTION
The Freedesktop SDK's libtiff is not full-featured so there are TIFF
files our build cannot create or open right now. This has been fixed
upstream but won't be available within the year most likely. So let's
build it ourselves for the time being.
Cf. https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1117