### PR TITLE
Change the application ID for the beta branch.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.gimp.GIMP",
+    "app-id": "org.gimp.GIMP.dev",
     "branch": "beta",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.36",


### PR DESCRIPTION
It's ugly but this is the only way to not have to manually switch the
flatpak branch through boring command lines.
See issue #91 and flatpak/flatpak#1109.