### PR TITLE
Build libXmu too.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -621,6 +621,16 @@
             ]
         },
         {
+            "name": "xmu",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://xorg.freedesktop.org/releases/individual/lib/libXmu-1.1.3.tar.bz2",
+                    "sha256": "9c343225e7c3dc0904f2122b562278da5fed639b1b5e880d25111561bac5b731"
+                }
+            ]
+        },
+        {
             "name": "babl",
             "buildsystem": "meson",
             "config-opts": [ "-Dwith-docs=false", "-Dlibdir=lib" ],


### PR DESCRIPTION
This allows the "Include window decoration" option in Screenshot
plug-in. Thanks to Christopher Davis to raise this option miss in:
https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/364