### PR TITLE
Plugins support

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -2,7 +2,7 @@
     "app-id": "org.gimp.GIMP",
     "branch": "beta",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "gimp-2.99",
     "separate-locales": false,
@@ -444,6 +444,9 @@
             "name": "gegl",
             "buildsystem": "meson",
             "config-opts": [ "-Ddocs=false", "-Dworkshop=true" ],
+            "build-options": {
+                "cppflags": "-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_60"
+            },
             "cleanup": [ "/bin" ],
             "sources": [
                 {

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -10,6 +10,7 @@
     "rename-icon": "gimp",
     "finish-args": ["--share=ipc", "--share=network",
                     "--socket=x11", "--socket=wayland",
+                    "--device=dri",
                     "--filesystem=host", "--filesystem=xdg-config/GIMP",
                     "--filesystem=xdg-config/gtk-3.0", "--filesystem=/tmp",
                     "--filesystem=xdg-run/gvfs",
@@ -17,9 +18,17 @@
                     "--talk-name=org.freedesktop.FileManager1"],
     "tags": ["GTK+3", "development"],
     "desktop-file-name-prefix": "(beta) ",
-    "cleanup": ["/include", "/lib/pkgconfig", "/share/pkgconfig",
-                "/share/aclocal", "/man", "/share/man", "/share/gtk-doc",
+    "cleanup": [ "/man", "/share/man", "/share/gtk-doc",
                 "/share/vala", "*.la", "*.a" ],
+    "add-extensions": {
+        "org.gimp.GIMP.Plugin": {
+            "version": "3",
+            "directory": "extensions/plug-ins",
+            "add-ld-path": "lib",
+            "subdirectories": true,
+            "no-autodownload": true
+        }
+    },
     "modules": [
         {
             "name": "gexiv2",
@@ -477,7 +486,7 @@
                              "--with-icc-directory=/run/host/usr/share/color/icc/",
                              "--with-build-id=org.gimp.GIMP.flatpak.dev",
                              "--disable-check-update" ],
-            "cleanup": [ "/bin/gimptool-2.99", "/bin/gimp-console-2.99" ],
+            "cleanup": [ "/bin/gimp-console-2.99" ],
             "sources": [
                 {
                     "type": "git",
@@ -495,6 +504,9 @@
                         "xsltproc -o desktop/org.gimp.GIMP.appdata.xml.in.in build/flatpak/remove-future-appdata-release.xslt desktop/org.gimp.GIMP.appdata.xml.in.in"
                     ]
                 }
+            ],
+	    "post-install": [
+                "install -d ${FLATPAK_DEST}/extensions/plug-ins"
             ]
         }
     ]


### PR DESCRIPTION
- Updated the runtime to GNOME 40
- Added DRI access (for anything GL)
- Added plugin support for GIMP 3

I have tested this with GMic that just got support for GIMP 3 (2.99.4)