### PR TITLE
Prepare GIMP 2.10.28.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -702,8 +702,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "tag": "GIMP_2_10_26",
-                    "commit": "1c7ff807ae9a0b4a9dd1f684ac859f84a4fac020"
+                    "branch": "gimp-2-10"
                 },
                 {
                     "type": "patch",

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -702,7 +702,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "branch": "gimp-2-10"
+                    "tag": "GIMP_2_10_28",
+                    "commit": "9f9ff10cf43ce824fd0e49594da3153e85caca45"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
Just because of an annoying build bug (one missing theme file). It's
basically the same as 2.10.26 otherwise.