### PR TITLE
Bump openexr from v2.3.0 to v2.5.7

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -121,6 +121,7 @@
             "modules": [
                 {
                     "name": "ilmbase",
+                    "subdir": "IlmBase",
                     "config-opts": [
                         "--disable-static"
                     ],
@@ -133,8 +134,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v2.3.0/ilmbase-2.3.0.tar.gz",
-                            "sha256": "456978d1a978a5f823c7c675f3f36b0ae14dba36638aeaa3c4b0e784f12a3862",
+                            "url": "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v2.5.7.tar.gz",
+                            "sha256": "36ecb2290cba6fc92b2ec9357f8dc0e364b4f9a90d727bf9a57c84760695272d",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 13289,
@@ -151,6 +152,7 @@
                     ]
                 }
             ],
+            "subdir": "OpenEXR",
             "config-opts": [
                 "--disable-static",
                 "--disable-ilmbasetest"
@@ -166,8 +168,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz",
-                    "sha256": "fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6",
+                    "url": "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v2.5.7.tar.gz",
+                    "sha256": "36ecb2290cba6fc92b2ec9357f8dc0e364b4f9a90d727bf9a57c84760695272d",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 13289,

--- a/patches/openexr-no-docs.patch
+++ b/patches/openexr-no-docs.patch
@@ -4,34 +4,20 @@ Date: Sun, 24 Apr 2016 13:45:12 +0200
 Subject: [PATCH] Don't build/install the documentation
 
 ---
- Makefile.am | 2 +-
- Makefile.in | 2 +-
+ OpenEXR/Makefile.am | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/Makefile.am b/Makefile.am
+diff --git a/OpenEXR/Makefile.am b/OpenEXR/Makefile.am
 index 3a232af..937133b 100644
---- a/Makefile.am
-+++ b/Makefile.am
+--- a/OpenEXR/Makefile.am
++++ b/OpenEXR/Makefile.am
 @@ -5,7 +5,7 @@
  ACLOCAL_AMFLAGS = -I m4
  
  SUBDIRS = config IlmImf IlmImfUtil IlmImfTest IlmImfUtilTest \
 -	  IlmImfFuzzTest exrheader exrmaketiled IlmImfExamples doc \
 +	  IlmImfFuzzTest exrheader exrmaketiled \
- 	  exrstdattr exrmakepreview exrenvmap exrmultiview exrmultipart
- 
- DIST_SUBDIRS = \
-diff --git a/Makefile.in b/Makefile.in
-index c63c319..2a9bae8 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -265,7 +265,7 @@ top_srcdir = @top_srcdir@
- # (an alternative to the acinclude.m4 mechanism)
- ACLOCAL_AMFLAGS = -I m4
- SUBDIRS = config IlmImf IlmImfUtil IlmImfTest IlmImfUtilTest \
--	  IlmImfFuzzTest exrheader exrmaketiled IlmImfExamples doc \
-+	  IlmImfFuzzTest exrheader exrmaketiled \
- 	  exrstdattr exrmakepreview exrenvmap exrmultiview exrmultipart
+ 	  exrstdattr exrmakepreview exrenvmap exrmultiview exrmultipart exr2aces
  
  DIST_SUBDIRS = \
 -- 


### PR DESCRIPTION
Flathub counterpart of https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/492

This required subtle changes to the manifest because the upstream
project no longer publishes separate tarballs with different parts
of the project.