### PR TITLE
Copy the icon on rename: suppress a warning

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -8,6 +8,7 @@
     "separate-locales": false,
     "rename-desktop-file": "gimp.desktop",
     "rename-icon": "gimp",
+    "copy-icon": true,
     "finish-args": [
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
There was a warning gimp couldn't find the gimp icon. Because it was renamed, so this time it gets copied.