### PR TITLE
Add version constraints for OpenEXR and mypaint-brushes

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -143,6 +143,9 @@
                                 "type": "anitya",
                                 "project-id": 13289,
                                 "stable-only": true,
+                                "versions": {
+                                    "<": "3.0.0"
+                                },
                                 "url-template": "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v$version.tar.gz"
                             }
                         },
@@ -177,6 +180,9 @@
                         "type": "anitya",
                         "project-id": 13289,
                         "stable-only": true,
+                        "versions": {
+                            "<": "3.0.0"
+                        },
                         "url-template": "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v$version.tar.gz"
                     }
                 },
@@ -391,6 +397,9 @@
                         "type": "anitya",
                         "project-id": 17096,
                         "stable-only": true,
+                        "versions": {
+                            "<": "2.0.0"
+                        },
                         "url-template": "https://github.com/mypaint/mypaint-brushes/releases/download/v$version/mypaint-brushes-$version.tar.xz"
                     }
                 }


### PR DESCRIPTION
OpenEXR and mypaint-brushes offer next major versions. GIMP is probably
not ready for the changes in OpenEXR and mypaint-brushes are not yet
finalized. Put their versions under constraints so that automatic PR
creation for dependency bumps can be enabled.

I'd postpone merging this until https://github.com/flathub/flatpak-external-data-checker/pull/265 is merged and a new version of the tool is released.