### PR TITLE
Replace C-style comments with JSON keys ignored by Flatpak

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -403,7 +403,7 @@
             ]
         },
         {
-            /* Shamelessly taken from org.octave.Octave manifest! */
+            "//": "Shamelessly taken from org.octave.Octave manifest!",
             "name": "SuiteSparse",
             "no-autogen": true,
             "make-args": [
@@ -720,7 +720,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    /*"tag": "BABL_0_1_92",*/
+                    "//": "\"tag\": \"BABL_0_1_92\"",
                     "commit": "befaba5cf1509d46fe27ccf609bd576db2bfebdc"
                 }
             ]


### PR DESCRIPTION
JSON does not support comments and their support in Flatpak is possible
through use of json-glib[0]. This is problematic in fully utilizing
flatpak-external-data-checker because its JSON writer does not respect
existing comments. To solve this, make use of Fltpak's specific
behaviour where a "//" key is explicitely ignored while parsing[1].

[0] https://github.com/flatpak/flatpak-builder/issues/363#issuecomment-710652526
[1] https://github.com/flatpak/flatpak-builder/blob/0e98b7ae191b81ff66d323ad5dabc2762c5f3f0c/src/builder-utils.c#L1250