### PR TITLE
Revert GNOME 43 bump because of glib 2 74 0

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -929,8 +929,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_92",
-                    "commit": "befaba5cf1509d46fe27ccf609bd576db2bfebdc"
+                    "tag": "BABL_0_1_98",
+                    "commit": "d26b50fb2647497b23445b4bfe220cd29b06c535"
                 }
             ]
         },
@@ -951,8 +951,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "tag": "GEGL_0_4_36",
-                    "commit": "31763e39265adab1142418f6d5cedbd4d3581e06"
+                    "tag": "GEGL_0_4_40",
+                    "commit": "b3222c10c5ce8760bcd2a603dad2b3deb50fde6c"
                 }
             ]
         },

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -2,7 +2,7 @@
     "app-id": "org.gimp.GIMP",
     "branch": "stable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "gimp-2.10",
     "separate-locales": false,
@@ -929,8 +929,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_96",
-                    "commit": "4fcc59632187d595df3443a94c78238af8c4867b"
+                    "tag": "BABL_0_1_92",
+                    "commit": "befaba5cf1509d46fe27ccf609bd576db2bfebdc"
                 }
             ]
         },
@@ -951,8 +951,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "tag": "GEGL_0_4_38",
-                    "commit": "b7fbf39e8010a95977a1642b747b94205892ea57"
+                    "tag": "GEGL_0_4_36",
+                    "commit": "31763e39265adab1142418f6d5cedbd4d3581e06"
                 }
             ]
         },


### PR DESCRIPTION
@hfiguiere @HarryMichal @novomesk I need to temporarily revert the GNOME 43 bump, at least from the stable flatpak, because the Glib packed in there contains a major crash bug. It used to be a big crash cause which most/all distributions were even patching a month before an actual GLib (2.74.1) got out with the fix.

Anyway we noticed that the GNOME 43 runtime contains the broken GLib so we started to get crash reports already. Therefore, I'm going to revert the runtime update.
I also asked the runtime maintainers to update GLib in there: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/575

@novomesk If I understood, you absolutely want the runtime 43 for the beta flatpak? I mean, it's a dev build, so we can live with the crash, but if we could avoid to get reports for outdated bugs, it would be better.