### PR TITLE
Bump back to GNOME runtime version 43.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -2,7 +2,7 @@
     "app-id": "org.gimp.GIMP",
     "branch": "stable",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "command": "gimp-2.10",
     "separate-locales": false,


### PR DESCRIPTION
GLib has now been updated appropriately to version 2.74.1: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/merge_requests/1862

Also reverting down the runtime bump most likely broke plug-ins since they had to be updated when we bumped to GNOME 43. See:

* https://github.com/flathub/org.gimp.GIMP/pull/159#issuecomment-1286129947
* https://gitlab.gnome.org/GNOME/gimp/-/issues/8861