### PR TITLE
Do not bump SuiteSparse to 6.x versions (at least for now).

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -864,8 +864,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/strukturag/libheif/releases/download/v1.13.0/libheif-1.13.0.tar.gz",
-                    "sha256": "c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1",
+                    "url": "https://github.com/strukturag/libheif/releases/download/v1.14.0/libheif-1.14.0.tar.gz",
+                    "sha256": "9a2b969d827e162fa9eba582ebd0c9f6891f16e426ef608d089b1f24962295b5",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 64439,

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -690,6 +690,10 @@
                         "type": "anitya",
                         "project-id": 4908,
                         "stable-only": true,
+                        "//": "patches don't apply. Avoiding flathubbot to spam us with broken updates",
+                        "versions": {
+                            "<": "6.0.0"
+                        },
                         "url-template": "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$version.tar.gz"
                     }
                 },


### PR DESCRIPTION
The patches don't apply anymore. Also it's a major version update and I haven't checked at all if API is stable and if it still works. Maybe it does, but it needs to be verified manually.

Last but not least, the flathubbot has been spamming us with broken MRs trying to bump this dependency lately. Worse: it breaks other dependency bumps from happening. So let's stick SuiteSparse to < 6.0.0 for the time being to unblock things and stop the bot spamming. We can unblock when one of the package contributors look at this dependency rule in detail (maybe also when org.octave.Octave do the work on their side too since this rule originally came from their manifest; I can see they haven't yet at time of writing).