### PR TITLE
Keep gimp-console in the flatpak.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -831,9 +831,6 @@
                 "-Dbuild-id=org.gimp.GIMP.flatpak.dev",
                 "-Dcheck-update=no"
             ],
-            "cleanup": [
-                "/bin/gimp-console-2.99"
-            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
Apparently some people want to use GIMP headless from the flatpak. Using gimp-console could be the easiest way then.
See: https://discourse.gnome.org/t/gimp-2-99-how-to-run-in-headless-batch-mode-on-a-server/13097/1