### PR TITLE
Update Cairo to version 1.17.8.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -937,17 +937,17 @@
         },
         {
             "name": "cairo",
-            "buildsystem": "autotools",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.gz",
-                    "sha256": "a2227afc15e616657341c42af9830c937c3a6bfa63661074eabef13600e8936f",
+                    "url": "https://cairographics.org/snapshots/cairo-1.17.8.tar.xz",
+                    "sha256": "5b10c8892d1b58d70d3f0ba5b47863a061262fa56b9dc7944161f8c8b783bc64",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 247,
                         "stable-only": true,
-                        "url-template": "https://gitlab.freedesktop.org/cairo/cairo/-/archive/$version/cairo-$version.tar.gz"
+                        "url-template": "https://cairographics.org/snapshots/cairo-$version.tar.xz"
                     }
                 }
             ]


### PR DESCRIPTION
The bot fails to build because since this version, Cairo build is meson-only.
See discussion in: https://gitlab.freedesktop.org/cairo/cairo/-/issues/622

Also using a different source URL, which is the one officially listed in the release news: https://cairographics.org/news/cairo-1.17.8/ I hope it won't clash with Anitya database which seems to favor the Gitlab source. But using static download servers is usually better when possible (especially when recommended by the project itself).