### PR TITLE
Revert babl for the "white text" bug.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -963,8 +963,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_100",
-                    "commit": "ee571ffe47a6831553b181f3b612fac745db8557"
+                    "tag": "BABL_0_1_102",
+                    "commit": "47affe964dc714f45f38ea04a07f6b632ab36040"
                 }
             ]
         },

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -938,17 +938,17 @@
         },
         {
             "name": "cairo",
-            "buildsystem": "autotools",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.gz",
-                    "sha256": "a2227afc15e616657341c42af9830c937c3a6bfa63661074eabef13600e8936f",
+                    "url": "https://cairographics.org/snapshots/cairo-1.17.8.tar.xz",
+                    "sha256": "5b10c8892d1b58d70d3f0ba5b47863a061262fa56b9dc7944161f8c8b783bc64",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 247,
                         "stable-only": true,
-                        "url-template": "https://gitlab.freedesktop.org/cairo/cairo/-/archive/$version/cairo-$version.tar.gz"
+                        "url-template": "https://cairographics.org/snapshots/cairo-$version.tar.xz"
                     }
                 }
             ]


### PR DESCRIPTION
I may have been too quick to publish the Cairo revert. Babl is a likely culprit. Let's try to revert it and take more time to test.