### PR TITLE
Update libjxl

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -922,8 +922,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libjxl/libjxl/archive/refs/tags/v0.8.1.tar.gz",
-                    "sha256": "60f43921ad3209c9e180563025eda0c0f9b1afac51a2927b9ff59fff3950dc56"
+                    "url": "https://github.com/libjxl/libjxl/archive/refs/tags/v0.8.2.tar.gz",
+                    "sha256": "c70916fb3ed43784eb840f82f05d390053a558e2da106e40863919238fa7b420"
                 }
             ]
         },


### PR DESCRIPTION
Update has fix for CVE-2023-35790 (an infinite loop bug).