### PR TITLE
Bump GNOME runtime, babl and GEGL.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -959,8 +959,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_102",
-                    "commit": "47affe964dc714f45f38ea04a07f6b632ab36040"
+                    "tag": "BABL_0_1_106",
+                    "commit": "150294d22e9f151ebe0ca7ac1c3a72135d2e850e"
                 }
             ]
         },
@@ -981,8 +981,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "tag": "GEGL_0_4_44",
-                    "commit": "f58385300356e739491b4cf803e0f9591e34dd40"
+                    "tag": "GEGL_0_4_46",
+                    "commit": "e6cb97763e422d8853fc95c665f8b0c73f025dd8"
                 }
             ]
         },


### PR DESCRIPTION
Synced back from the beta manifest where these build fine.