### PR TITLE
Move HEIC support to an extension

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -39,6 +39,12 @@
         "*.a"
     ],
     "add-extensions": {
+        "org.gimp.GIMP.HEIC": {
+            "directory": "lib/libheif",
+            "add-ld-path": "lib",
+            "bundle": true,
+            "autodelete": true
+        },
         "org.gimp.GIMP.Plugin": {
             "version": "3",
             "directory": "extensions/plug-ins",
@@ -492,15 +498,18 @@
             "config-opts": [
                 "-DWITH_GDK_PIXBUF=OFF",
                 "-DWITH_EXAMPLES=OFF",
-                "-DENABLE_PLUGIN_LOADING=OFF",
-                "-DWITH_LIBDE265=ON",
-                "-DWITH_X265=ON",
+                "-DENABLE_PLUGIN_LOADING=ON",
+                "-DWITH_LIBDE265_PLUGIN=ON",
+                "-DWITH_X265_PLUGIN=ON",
                 "-DWITH_DAV1D=ON",
                 "-DWITH_AOM_DECODER=ON",
                 "-DWITH_AOM_ENCODER=ON",
                 "-DWITH_JPEG_DECODER=ON",
                 "-DWITH_OpenJPEG_DECODER=ON"
             ],
+            "build-options": {
+                "append-pkg-config-path": "/app/lib/libheif/lib/pkgconfig"
+            },
             "cleanup": [
                 "/bin",
                 "/share/thumbnailers"
@@ -510,12 +519,13 @@
                     "name": "libde265",
                     "buildsystem": "cmake-ninja",
                     "config-opts": [
+                        "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
                         "-DENABLE_SDL=OFF",
                         "-DENABLE_DECODER=OFF",
                         "-DENABLE_ENCODER=OFF"
                     ],
                     "cleanup": [
-                        "/bin"
+                        "/lib/libheif/bin"
                     ],
                     "sources": [
                         {
@@ -536,13 +546,14 @@
                     "buildsystem": "cmake",
                     "subdir": "source",
                     "config-opts": [
+                        "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
                         "-DEXTRA_LIB='libx265-10.a;libx265-12.a'",
-                        "-DEXTRA_LINK_FLAGS=-L.",
+                        "-DEXTRA_LINK_FLAGS=-L/app/lib/libheif/lib",
                         "-DLINKED_10BIT=ON",
                         "-DLINKED_12BIT=ON"
                     ],
                     "cleanup": [
-                        "/bin"
+                        "/lib/libheif/bin"
                     ],
                     "sources": [
                         {
@@ -559,9 +570,9 @@
                         {
                             "type": "shell",
                             "commands": [
-                                "ln -s ${FLATPAK_DEST}/lib/libx265-10.a",
-                                "ln -s ${FLATPAK_DEST}/lib/libx265-12.a",
-                                "rm -fr ${FLATPAK_DEST}/lib/libx265.so*"
+                                "ln -s ${FLATPAK_DEST}/lib/libheif/lib/libx265-10.a",
+                                "ln -s ${FLATPAK_DEST}/lib/libheif/lib/libx265-12.a",
+                                "rm -fr ${FLATPAK_DEST}/lib/libheif/lib/libx265.so*"
                             ]
                         }
                     ],
@@ -571,6 +582,7 @@
                             "buildsystem": "cmake",
                             "subdir": "source",
                             "config-opts": [
+                                "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
                                 "-DHIGH_BIT_DEPTH=ON",
                                 "-DEXPORT_C_API=OFF",
                                 "-DENABLE_SHARED=OFF",
@@ -591,7 +603,7 @@
                                 }
                             ],
                             "post-install": [
-                                "mv ${FLATPAK_DEST}/lib/libx265.a ${FLATPAK_DEST}/lib/libx265-10.a"
+                                "mv ${FLATPAK_DEST}/lib/libheif/lib/libx265.a ${FLATPAK_DEST}/lib/libheif/lib/libx265-10.a"
                             ]
                         },
                         {
@@ -599,6 +611,7 @@
                             "buildsystem": "cmake",
                             "subdir": "source",
                             "config-opts": [
+                                "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
                                 "-DHIGH_BIT_DEPTH=ON",
                                 "-DEXPORT_C_API=OFF",
                                 "-DENABLE_SHARED=OFF",
@@ -620,7 +633,7 @@
                                 }
                             ],
                             "post-install": [
-                                "mv ${FLATPAK_DEST}/lib/libx265.a ${FLATPAK_DEST}/lib/libx265-12.a"
+                                "mv ${FLATPAK_DEST}/lib/libheif/lib/libx265.a ${FLATPAK_DEST}/lib/libheif/lib/libx265-12.a"
                             ]
                         }
                     ]

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -525,7 +525,8 @@
                         "-DENABLE_ENCODER=OFF"
                     ],
                     "cleanup": [
-                        "/lib/libheif/bin"
+                        "/lib/libheif/bin",
+                        "/lib/libheif/include"
                     ],
                     "sources": [
                         {
@@ -553,7 +554,8 @@
                         "-DLINKED_12BIT=ON"
                     ],
                     "cleanup": [
-                        "/lib/libheif/bin"
+                        "/lib/libheif/bin",
+                        "/lib/libheif/include"
                     ],
                     "sources": [
                         {

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -502,10 +502,12 @@
                 "-DWITH_LIBDE265_PLUGIN=ON",
                 "-DWITH_X265_PLUGIN=ON",
                 "-DWITH_DAV1D=ON",
+                "-DWITH_DAV1D_PLUGIN=OFF",
                 "-DWITH_AOM_DECODER=ON",
                 "-DWITH_AOM_ENCODER=ON",
                 "-DWITH_JPEG_DECODER=ON",
-                "-DWITH_OpenJPEG_DECODER=ON"
+                "-DWITH_OpenJPEG_DECODER=ON",
+                "-DWITH_OpenJPEG_DECODER_PLUGIN=OFF"
             ],
             "build-options": {
                 "append-pkg-config-path": "/app/lib/libheif/lib/pkgconfig"

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -544,7 +544,7 @@
                 },
                 {
                     "name": "libx265",
-                    "buildsystem": "cmake",
+                    "buildsystem": "cmake-ninja",
                     "subdir": "source",
                     "config-opts": [
                         "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
@@ -581,7 +581,7 @@
                     "modules": [
                         {
                             "name": "libx265-10bpc",
-                            "buildsystem": "cmake",
+                            "buildsystem": "cmake-ninja",
                             "subdir": "source",
                             "config-opts": [
                                 "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
@@ -610,7 +610,7 @@
                         },
                         {
                             "name": "libx265-12bpc",
-                            "buildsystem": "cmake",
+                            "buildsystem": "cmake-ninja",
                             "subdir": "source",
                             "config-opts": [
                                 "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -472,8 +472,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/xianyi/OpenBLAS/archive/v0.3.24.tar.gz",
-                            "sha256": "ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132",
+                            "url": "https://github.com/xianyi/OpenBLAS/archive/v0.3.25.tar.gz",
+                            "sha256": "4c25cb30c4bb23eddca05d7d0a85997b8db6144f5464ba7f8c09ce91e2f35543",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 2540,
@@ -712,7 +712,9 @@
             "config-opts": [
                 "--enable-reentrant"
             ],
-            "make-args": ["shared"],
+            "make-args": [
+                "shared"
+            ],
             "cleanup": [
                 "/include",
                 "/lib/*.a",
@@ -784,8 +786,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://gitlab.com/graphviz/graphviz/-/archive/8.0.5/graphviz-8.0.5.tar.gz",
-                            "sha256": "dd06f45f5bbcb1c7cbc67adab5359da2cd4b40533dc7c7424b3fc0e998bbd6c9",
+                            "url": "https://gitlab.com/graphviz/graphviz/-/archive/9.0.0/graphviz-9.0.0.tar.gz",
+                            "sha256": "504d19b5d0e5398a57e9d9de42393f90b9e79aff0969b4ebc3b891ccb39602ed",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 1249,


### PR DESCRIPTION
HEIC is patent-encumbered.  Some distributors or users may prefer not to
have such codecs installed on their system.

libheif has an optional plugin system, where codecs can be compiled as
separate shared objects. At runtime, libheif dynamically loads any such
codecs it finds in its search path. The search path comes out as
/app/lib/libheif, adjacent to the libheif library itself.

Configure libheif to build its libde265 and x265 support as plugins, and
then split the /app/lib/libheif directory into an extension. Move the
libde265 and x265 libraries themselves to a subdirectory, and use
add-ld-path to place /app/lib/libheif/lib onto the library search path
if the extension is installed.

With these changes, the org.gimp.GIMP.HEIC extension will be installed &
uninstalled automatically with the main application, unless the
distributor or user explicitly choses not to install it (via `flatpak
install --no-related`, `flatpak mask`, or some other means). Support for
other formats in a HEIF container, such as AVIF, are always supported;
HEIC is only supported if org.gimp.GIMP.HEIC is installed.
    
Fixes #111.