### PR TITLE
Exiv2 version 0.28.1 just got released.

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -327,13 +327,13 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/Exiv2/exiv2/releases/download/v0.28.0/exiv2-0.28.0-Source.tar.gz",
-                            "sha256": "89af3b5ef7277753ef7a7b5374ae017c6b9e304db3b688f1948e73e103491f3d",
+                            "url": "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.1.tar.gz",
+                            "sha256": "3078651f995cb6313b1041f07f4dd1bf0e9e4d394d6e2adc6e92ad0b621291fa",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 769,
                                 "stable-only": true,
-                                "url-template": "https://github.com/Exiv2/exiv2/releases/download/v$version/exiv2-$version-Source.tar.gz"
+                                "url-template": "https://github.com/Exiv2/exiv2/archive/refs/tags/v$version.tar.gz"
                             }
                         }
                     ]

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -1,6 +1,5 @@
 {
     "app-id": "org.gimp.GIMP",
-    "branch": "stable",
     "runtime": "org.gnome.Platform",
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",


### PR DESCRIPTION
For some reason, the build to release GIMP 2.10.36 a few days ago failed (I should have followed through): https://buildbot.flathub.org/#/builders/6/builds/79515

I tried to trigger a new build manually, but now I get new errors because Exiv2 just released a new version: https://buildbot.flathub.org/#/builders/42/builds/7201

So anyway updating Exiv2 to finally be able to upload the new GIMP version.