### PR TITLE
Fix build: remove group GNOME in appstream

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -1011,11 +1011,11 @@
                 {
                     "type": "patch",
                     "use-git": true,
-                    "path": "patches/0001-desktop-rename-launchable-in-appdata.patch"
-                },
-                {
-                    "type": "patch",
-                    "path": "patches/gimp-extension-path.patch"
+                    "paths": [
+                        "patches/0001-desktop-rename-launchable-in-appdata.patch",
+                        "patches/0002-appdata-remove-group.patch",
+                        "patches/gimp-extension-path.patch"
+                    ]
                 }
             ],
             "post-install": [

--- a/patches/0002-appdata-remove-group.patch
+++ b/patches/0002-appdata-remove-group.patch
@@ -1,0 +1,12 @@
+diff --git a/desktop/org.gimp.GIMP.appdata.xml.in.in b/desktop/org.gimp.GIMP.appdata.xml.in.in
+index 91e470876a..ffbfcc8746 100644
+--- a/desktop/org.gimp.GIMP.appdata.xml.in.in
++++ b/desktop/org.gimp.GIMP.appdata.xml.in.in
+@@ -61,7 +61,6 @@
+     <kudo>ModernToolkit</kudo>
+     <kudo>UserDocs</kudo>
+   </kudos>
+-  <project_group>GNOME</project_group>
+   <translation type="gettext">gimp20</translation>
+ 
+   <launchable type="desktop-id">org.gimp.GIMP.desktop</launchable>


### PR DESCRIPTION
This should fix the build for `stable`