### PR TITLE
Remove custom libjxl build

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -870,57 +870,6 @@
             ]
         },
         {
-            "name": "libjxl",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DJPEGXL_ENABLE_BENCHMARK=OFF",
-                "-DJPEGXL_ENABLE_DOXYGEN=OFF",
-                "-DJPEGXL_ENABLE_EXAMPLES=OFF",
-                "-DJPEGXL_ENABLE_JNI=OFF",
-                "-DJPEGXL_ENABLE_JPEGLI_LIBJPEG=OFF",
-                "-DJPEGXL_ENABLE_MANPAGES=OFF",
-                "-DJPEGXL_ENABLE_PLUGINS=OFF",
-                "-DJPEGXL_ENABLE_SJPEG=OFF",
-                "-DJPEGXL_ENABLE_SKCMS=OFF",
-                "-DJPEGXL_ENABLE_TCMALLOC=OFF",
-                "-DJPEGXL_ENABLE_TOOLS=OFF",
-                "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
-                "-DJPEGXL_FORCE_SYSTEM_HWY=ON",
-                "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON",
-                "-DJPEGXL_WARNINGS_AS_ERRORS=OFF"
-            ],
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "modules": [
-                {
-                    "name": "libhwy",
-                    "config-opts": [
-                        "-DBUILD_TESTING=OFF",
-                        "-DBUILD_SHARED_LIBS=OFF",
-                        "-DHWY_ENABLE_EXAMPLES=OFF",
-                        "-DHWY_ENABLE_TESTS=OFF",
-                        "-DHWY_FORCE_STATIC_LIBS=ON"
-                    ],
-                    "buildsystem": "cmake-ninja",
-                    "builddir": true,
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://github.com/google/highway/archive/refs/tags/1.0.3.tar.gz",
-                            "sha256": "566fc77315878473d9a6bd815f7de78c73734acdcb745c3dde8579560ac5440e"
-                        }
-                    ]
-                }
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libjxl/libjxl/archive/refs/tags/v0.8.2.tar.gz",
-                    "sha256": "c70916fb3ed43784eb840f82f05d390053a558e2da106e40863919238fa7b420"
-                }
-            ]
-        },
-        {
             "name": "xmu",
             "sources": [
                 {


### PR DESCRIPTION
This was already done in beta flatpak: acec036cbee739e852e9358c9dddd246a7085520

See the discussion in: https://gitlab.gnome.org/GNOME/gimp/-/issues/9785

