### PR TITLE
graphviz: Update to 12.0.0

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -847,8 +847,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://gitlab.com/graphviz/graphviz/-/archive/9.0.0/graphviz-9.0.0.tar.gz",
-                            "sha256": "504d19b5d0e5398a57e9d9de42393f90b9e79aff0969b4ebc3b891ccb39602ed",
+                            "url": "https://gitlab.com/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.tar.gz",
+                            "sha256": "ea12b4f73e7c7eb9fb9c1c29f7763491306c322f6f2332a352d09debc37f0ed7",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 1249,
@@ -874,7 +874,6 @@
                         "/bin/nop",
                         "/include",
                         "/lib/libgvpr*",
-                        "/lib/liblab*",
                         "/lib/graphviz/libgvplugin_core*",
                         "/lib/graphviz/libgvplugin_kitty*",
                         "/lib/graphviz/libgvplugin_neato_layout*",


### PR DESCRIPTION
Also, drop liblab cleanup since it isn't built anymore