### PR TITLE
Don't cleanup gexiv2 headers / pkconfig

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -128,10 +128,6 @@
                 "-Dtools=false",
                 "-Dvapi=false"
             ],
-            "cleanup": [
-                "/include",
-                "/lib/pkgconfig"
-            ],
             "modules": [
                 {
                     "name": "exiv2",


### PR DESCRIPTION
This is required to build plugins like GMIC

This is a regression from #321 