### PR TITLE
Don't cleanup exiv2 headers / pkconfig

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -150,10 +150,6 @@
                         "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",
                         "-DEXIV2_ENABLE_INIH=OFF",
                         "-DEXIV2_ENABLE_VIDEO=OFF"
-                    ],
-                    "cleanup": [
-                        "/include",
-                        "/lib/pkgconfig"
                     ]
                 }
             ]


### PR DESCRIPTION
This is required by gexiv2 which is required to build plugins like GMIC Follow-up for #348