### PR TITLE
plug-ins: change the extension path

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -61,8 +61,9 @@
         },
         "org.gimp.GIMP.Plugin": {
             "version": "3",
-            "directory": "extensions/plug-ins",
+            "directory": "extensions",
             "add-ld-path": "lib",
+            "merge-dirs": "plug-ins;scripts",
             "subdirectories": true,
             "no-autodownload": true
         }


### PR DESCRIPTION
This should help fixing https://github.com/flathub/org.gimp.GIMP.Plugin.Resynthesizer/issues/14


This is an important change and I will update all the GIMP 3 plugins to work.