### PR TITLE
gegl: Remove obsolete Glib requirement

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -915,9 +915,6 @@
                 "-Ddocs=false",
                 "-Dgi-docgen=disabled"
             ],
-            "build-options": {
-                "cppflags": "-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_60"
-            },
             "cleanup": [
                 "/bin/gegl-imgcmp",
                 "/share/gegl*"


### PR DESCRIPTION
This was added in a93bb3ef0e68f0a4d794189647f3426c1b7de289 and it isn't needed anymore.