### PR TITLE
.github: Make update check per-branch

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,13 +7,10 @@ jobs:
   flatpak-external-data-checker:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'flathub'
-    strategy:
-      matrix:
-        branch: [ master, beta ]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          ref: master
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
@@ -23,4 +20,4 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --never-fork org.gimp.GIMP.json
+          args: --update --never-fork --pr-labels="1. Stable" org.gimp.GIMP.json

--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -97,13 +97,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://people.freedesktop.org/~hughsient/appstream-glib/releases/appstream-glib-0.8.3.tar.xz",
-                    "sha256": "84754064c560fca6e1ab151dc64354fc235a5798f016b91b38c9617253a8cf11",
+                    "url": "https://github.com/hughsie/appstream-glib/archive/refs/tags/appstream_glib_0_8_3.zip",
+                    "sha256": "d9d3c5cc690c1f0ccd630c4f70298ee68277586a59500a9cb04b8e8b2c0ae7e6",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 14018,
                         "stable-only": true,
-                        "url-template": "https://people.freedesktop.org/~hughsient/appstream-glib/releases/appstream-glib-$version.tar.xz"
+                        "url-template": "https://github.com/hughsie/appstream-glib/archive/refs/tags/appstream_glib_$version.zip"
                     }
                 }
             ],


### PR DESCRIPTION
Enhances #437

---

This enables greater control on GitHub Actions UI (if the maintainer wants to run a manual pipeline):

![Captura de tela 2025-06-14 085944](https://github.com/user-attachments/assets/a35d0b55-2779-4ef9-80e4-e19d322bcffe)

And auto set proper MR labels.

![Captura de tela 2025-06-14 090123](https://github.com/user-attachments/assets/585aa135-d208-454f-9abd-50206675617c)

Also, this reduces a bit the git diff output.