### PR TITLE
github, flathub: Move flatpak-external-data-checker back to matrix

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,10 +7,13 @@ jobs:
   flatpak-external-data-checker:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'flathub'
+    strategy:
+      matrix:
+        branch: [ master, beta ]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ matrix.branch }}
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
@@ -20,4 +23,4 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --never-fork --pr-labels="1. Stable" org.gimp.GIMP.json
+          args: --update --never-fork --pr-labels="${{ matrix.branch == 'master' && '1. Stable' || '1. Beta' }}" org.gimp.GIMP.json

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "//": "Since we run flatpak-external-data-checker with GH Actions for both branches, we need to disable the default of running on its own on 'master'",
+  "//": "Since we run flatpak-external-data-checker ourselves to allow checking both branches (see .github/workflows/update.yaml), we need to disable the default of running on its own on 'master'",
   "disable-external-data-checker": true
 }


### PR DESCRIPTION
It is simply not running on beta branch.

This restores the behavior of #437 but with proper MR labels.