### PR TITLE
manifest: Fix OpenBLAS comment position

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -806,8 +806,8 @@
                                 "type": "anitya",
                                 "project-id": 2540,
                                 "stable-only": true,
+                                "//": "https://github.com/OpenMathLib/OpenBLAS/issues/5324",
                                 "versions": {
-                                    "//": "https://github.com/OpenMathLib/OpenBLAS/issues/5324",
                                     "<": "0.3.30"
                                 },
                                 "url-template": "https://github.com/xianyi/OpenBLAS/archive/v$version.tar.gz"


### PR DESCRIPTION
Inside "version" make flatpak-external-data-checker fail