### PR TITLE
manifest: Restrict Gexiv2 module version to the API we support

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -136,6 +136,10 @@
                         "type": "anitya",
                         "project-id": 1626,
                         "stable-only": true,
+                        "//": "https://gitlab.gnome.org/GNOME/gexiv2/-/issues/82",
+                        "versions": {
+                            "<": "0.15.0"
+                        },
                         "url-template": "https://download.gnome.org/sources/gexiv2/$major.$minor/gexiv2-$version.tar.xz"
                     }
                 }
@@ -472,6 +476,7 @@
                         "type": "anitya",
                         "project-id": 17096,
                         "stable-only": true,
+                        "//": "https://github.com/mypaint/libmypaint/issues/101",
                         "versions": {
                             "<": "2.0.0"
                         },


### PR DESCRIPTION
See the explanation in: https://gitlab.gnome.org/GNOME/gimp/-/issues/14361