### PR TITLE
manifest: Add extension point to 'org.gimp.GIMP.Manual'

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -66,6 +66,12 @@
             "merge-dirs": "plug-ins;scripts",
             "subdirectories": true,
             "no-autodownload": true
+        },
+        "org.gimp.GIMP.Manual": {
+            "version": "3.0",
+            "directory": "share/gimp/3.0/help",
+            "locale-subset": true,
+            "no-autodownload": true
         }
     },
     "modules": [


### PR DESCRIPTION
Not working yet. Will work after the fix on
org.gimp.GIMP.Manual flatpak build.