### PR TITLE
Change filesystem option from host to xdg-pictures

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -22,7 +22,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--filesystem=host",
+        "--filesystem=xdg-pictures",
         "--filesystem=xdg-config/GIMP:create",
         "--filesystem=xdg-config/gtk-3.0",
         "--filesystem=/tmp",


### PR DESCRIPTION
Remove write access to `host` and replace with write access to `xdg-pictures` . This follows good practice to make the sandboxing more robust. If `xdg-pictures` is not the right path or an adequate path, we can add an additional one. 

When I try to save or export a project, only the allow-listed filesystem path are shown in the file browser.