### PR TITLE
manifest: Avoid noisy warnings about GTK_MODULES

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -28,6 +28,7 @@
         "--filesystem=/tmp",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
+        "--unset-env=GTK_MODULES",
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.freedesktop.FileManager1",
         "--talk-name=org.gnome.Shell.Screenshot",


### PR DESCRIPTION
Ported from: https://gitlab.gnome.org/GNOME/gimp/-/commit/47eac319b1d8f4f9eac631037e8183c32a625d47