### PR TITLE
manifest: Create pseudo-release on AppData if non tagged

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -784,7 +784,8 @@
                 {
                     "type": "shell",
                     "commands": [
-                        "xsltproc -o desktop/org.gimp.GIMP.appdata.xml.in.in build/linux/flatpak/remove-future-appdata-release.xslt desktop/org.gimp.GIMP.appdata.xml.in.in"
+                        "sed -i \"/<release[^>]*date=\\\"TODO\\\"[^>]*>/,/<\\/release>/d\" desktop/org.gimp.GIMP.appdata.xml.in.in",
+                        "v=$(awk -F\"'\" '/version:/ {print $2; exit}' meson.build | sed 's/-/~/g' | tr '[:upper:]' '[:lower:]'); grep -q \"version=\\\"$v\\\"\" desktop/org.gimp.GIMP.appdata.xml.in.in || sed -i \"/<releases>/a <release version=\\\"$v\\\" date=\\\"$(date --iso-8601)\\\" type=\\\"snapshot\\\"></release>\" desktop/org.gimp.GIMP.appdata.xml.in.in"
                     ]
                 },
                 {


### PR DESCRIPTION
Ported from: https://gitlab.gnome.org/GNOME/gimp/-/commit/6f6329744de92cfa654e3fe57b1a2652a23279a5

This is useful when we are testing release MRs before merging.