### PR TITLE
manifest:Make meson build options order more consistent

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -737,8 +737,8 @@
             ],
             "buildsystem": "meson",
             "config-opts": [
-                "-Dwith-docs=false",
-                "-Dgi-docgen=disabled"
+                "-Dgi-docgen=disabled",
+                "-Dwith-docs=false"
             ],
             "cleanup": [
                 "/bin"
@@ -756,8 +756,8 @@
             ],
             "buildsystem": "meson",
             "config-opts": [
-                "-Ddocs=false",
-                "-Dgi-docgen=disabled"
+                "-Dgi-docgen=disabled",
+                "-Ddocs=false"
             ],
             "cleanup": [
                 "/bin/gegl-imgcmp",
@@ -789,8 +789,8 @@
             ],
             "buildsystem": "meson",
             "config-opts": [
-                "-Dgi-docgen=disabled",
                 "-Dicc-directory=/run/host/usr/share/color/icc/",
+                "-Dgi-docgen=disabled",
                 "-Dcheck-update=no",
                 "-Denable-default-bin=enabled",
                 "-Dbuild-id=org.gimp.GIMP.flatpak.dev"


### PR DESCRIPTION
Ported from https://gitlab.gnome.org/GNOME/gimp/-/commit/2d64114e60b9c525a7ff92f5c2cc05ab54dfeac7