### PR TITLE
manifest: Use legacy --device=all on Flatpak to support Pendrive, MID…

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -21,7 +21,7 @@
         "--share=network",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--device=dri",
+        "--device=all",
         "--filesystem=host",
         "--filesystem=xdg-config/GIMP:create",
         "--filesystem=xdg-config/gtk-3.0",


### PR DESCRIPTION
…I etc

Ported from https://gitlab.gnome.org/GNOME/gimp/-/commit/1f56b60a71f1c03babcd616619faa3792e446795