### PR TITLE
babl: Fix x86_64-v4 micro-architecture being used on v2

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -733,8 +733,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_120",
-                    "commit": "66ef020fe111d93dab76baf9ffad0683c226c4de"
+                    "tag": "BABL_0_1_122",
+                    "commit": "fbd72abf40672d323c8fad6381730f132e456948"
                 }
             ],
             "buildsystem": "meson",


### PR DESCRIPTION
See: https://gitlab.gnome.org/GNOME/gimp/-/issues/15766#note_2664176