### PR TITLE
Release GIMP 3.2.0 RC3

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -723,8 +723,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_118",
-                    "commit": "b47df7d3da1fdd3bf751a369a7ce453a63b2bebf"
+                    "tag": "BABL_0_1_122",
+                    "commit": "fbd72abf40672d323c8fad6381730f132e456948"
                 }
             ],
             "buildsystem": "meson",
@@ -762,8 +762,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "tag": "GIMP_3_2_0_RC2",
-                    "commit": "25e96437550cc118a04f4df400499bdc9d8d3cc0"
+                    "tag": "GIMP_3_2_0_RC3",
+                    "commit": "c4dd447133d91d2ce423b93f86179e099b265882"
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
See: https://gitlab.gnome.org/GNOME/gimp/-/issues/15794#note_2681703