### PR TITLE
Release GIMP 3.2.0

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -723,8 +723,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/babl.git",
-                    "tag": "BABL_0_1_122",
-                    "commit": "fbd72abf40672d323c8fad6381730f132e456948"
+                    "tag": "BABL_0_1_124",
+                    "commit": "535d66b5e13ec65e5db1bb944a3e3ee5783182a8"
                 }
             ],
             "buildsystem": "meson",
@@ -742,8 +742,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gegl.git",
-                    "tag": "GEGL_0_4_66",
-                    "commit": "3ed6237faa44bc64bdff8dcb2750c734ac680d40"
+                    "tag": "GEGL_0_4_68",
+                    "commit": "377a737cdfcddf81c41ba5938f061d2b331f2df6"
                 }
             ],
             "buildsystem": "meson",
@@ -762,8 +762,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gimp.git",
-                    "tag": "GIMP_3_2_0_RC3",
-                    "commit": "c4dd447133d91d2ce423b93f86179e099b265882"
+                    "tag": "GIMP_3_2_0",
+                    "commit": "edbd1ea7384e63efa8fe326dd79ffe4fbe6722db"
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
Let's not keep the beta channel lagging behind the main channel.