### PR TITLE
Make gtk-config dir as read-only (#722)

### DIFF
--- a/org.gimp.GIMP.json
+++ b/org.gimp.GIMP.json
@@ -25,7 +25,7 @@
         "--device=all",
         "--filesystem=host",
         "--filesystem=xdg-config/GIMP:create",
-        "--filesystem=xdg-config/gtk-3.0",
+        "--filesystem=xdg-config/gtk-3.0:ro",
         "--filesystem=/tmp",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",


### PR DESCRIPTION
Write access shouldn't be needed there, see https://github.com/flathub/org.gtk.Gtk3theme.Breeze#workarounds

(cherry picked from commit d606d0fccbe4f2d3bef9eefd92909b7cf84c6eab)